### PR TITLE
Update StarRating.php change input field to hidden

### DIFF
--- a/StarRating.php
+++ b/StarRating.php
@@ -48,7 +48,7 @@ class StarRating extends InputWidget
         if ($this->pluginLoading) {
             Html::addCssClass($this->options, 'rating-loading');
         }
-        echo $this->getInput('textInput');
+        echo $this->getInput('hiddenInput');
     }
 
     /**


### PR DESCRIPTION
Change the input field type from text to hidden.
There is no need that the text input is rendered and uses "space" in the output.
There could be lines etc. when you generate a custom theme.

Of course the field could also set to visibility hidden by css but i guess a better solution is to create a hidden field directly.

## Scope
This pull request includes a

- [x ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

- change the textInput to hiddenInput


## Related Issues
https://github.com/kartik-v/yii2-widget-rating/issues/12
